### PR TITLE
Optimize Dockerfile base images to use slim variants

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM oven/bun:alpine AS dev
-RUN apk add curl --no-cache
+FROM oven/bun:slim AS dev
 WORKDIR /app
 ENTRYPOINT ["/usr/local/bin/bun"]
 
 
-FROM oven/bun:alpine AS base
+FROM oven/bun:slim AS base
 WORKDIR /app
 COPY *.js *.json *.ts bun.lock drizzle /app/
 RUN bun install --omit=dev --frozen-lockfile
@@ -15,8 +14,7 @@ RUN bun --bun run build-server && bun --bun run build-worker && \
     echo "Build timestamp: $timestamp" && \
     echo "$timestamp" > /app/build/BUILD_TIME
 
-FROM oven/bun:alpine AS release
-RUN apk add curl --no-cache
+FROM oven/bun:slim AS release
 WORKDIR /app
 COPY drizzle/ /app/drizzle/
 COPY --from=base /app/build/ /app/


### PR DESCRIPTION
- Switch base images from alpine to slim variants
- Remove unnecessary curl installation
- Maintain consistent Dockerfile structure across dev, base, and release stages