### PR TITLE
fix: update docker healthcheck endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
         order: start-first
       replicas: ${APP_REPLICAS:-1}
     healthcheck:
-      test: "curl -f --head http://localhost:3000/api/health || exit 1"
+      test: "curl -L http://localhost:3000/health || exit 1"
       interval: 5s
       timeout: 3s
       retries: 3


### PR DESCRIPTION
Modify docker-compose healthcheck to use /health endpoint instead of /api/health and add -L flag to follow redirects