### PR TITLE
Refactor health check logic in Docker build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -97,19 +97,22 @@ jobs:
             # Wait for services to be healthy
             echo "Waiting for services to be healthy..." && \
             MAX_ATTEMPTS=150 && \
-            for service in server worker mail; do
-              echo "Checking health of \$service..." && \
-              attempts=0 && \
-              until docker compose -f docker-compose.yml -f docker-compose-traefik.yml ps | \
-                grep -q "\$service.*(healthy)"; do
-                attempts=\$((attempts + 1)) && \
-                if [ \$attempts -ge \$MAX_ATTEMPTS ]; then
-                  echo "Timeout waiting for \$service to become healthy after 5 minutes" >&2
-                  exit 1
-                fi && \
-                echo "Service \$service is not healthy yet, waiting... (attempt \$attempts/\$MAX_ATTEMPTS)" && \
-                sleep 2
-              done
-              echo "Service \$service is now healthy"
-            done
+            attempts=0 && \
+            until docker compose -f docker-compose.yml -f docker-compose-traefik.yml ps | \
+              grep -q "server.*(healthy)" && \
+              docker compose -f docker-compose.yml -f docker-compose-traefik.yml ps | \
+              grep -q "worker.*(healthy)" && \
+              docker compose -f docker-compose.yml -f docker-compose-traefik.yml ps | \
+              grep -q "mail.*(healthy)"; do
+              attempts=\$((attempts + 1)) && \
+              if [ \$attempts -ge \$MAX_ATTEMPTS ]; then
+                echo "Timeout waiting for services to become healthy after 5 minutes" >&2
+                echo "Current status:" >&2
+                docker compose -f docker-compose.yml -f docker-compose-traefik.yml ps | grep -E "server|worker|mail" >&2
+                exit 1
+              fi && \
+              echo "Waiting for all services to be healthy... (attempt \$attempts/\$MAX_ATTEMPTS)" && \
+              sleep 2
+            done && \
+            echo "All services are now healthy"
           EOF


### PR DESCRIPTION
- Simplify the health check command in docker-build.yml to wait for all services (server, worker, mail) to be healthy in a single loop.
- Enhance error reporting by displaying the current status of services if the timeout is reached, improving debugging capabilities.